### PR TITLE
ENH: Add resolutions and limits to archive and autosave

### DIFF
--- a/app/Db/EthercatMC.template
+++ b/app/Db/EthercatMC.template
@@ -29,8 +29,8 @@ record(motor,"$(PREFIX)$(MOTOR_NAME)")
     field(VBAS,"$(VBAS=0)")
     field(VELO,"$(VELO=0)")
     info(autosaveFields_pass0, "VAL DVAL")
-    info(autosaveFields, "ACCL DESC DIR EGU FOFF OFF PREC VBAS VELO VMAX")
-    info(archive, "ACCL DESC DIR DVAL EGU FOFF OFF PREC RBV RRBV RVAL SPDB VAL VBAS VELO VMAX")
+    info(autosaveFields, "ACCL DESC DHLM DIR DLLM EGU ERES FOFF MRES OFF PREC VBAS VELO VMAX")
+    info(archive, "ACCL DESC DHLM DIR DLLM DVAL EGU ERES FOFF MRES OFF PREC RBV RRBV RVAL SPDB VAL VBAS VELO VMAX")
 }
 
 # The message text


### PR DESCRIPTION
Very simple PR: added `DHLM`, `DLLM`, `ERES`, and `MRES` fields to the archive and autosave lists.
Resolutions _probably_ don't need to be archived, but I added them anyway. Lmk if I should take them out.